### PR TITLE
Disable NuGet version updates for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
+  #- package-ecosystem: "nuget" # See documentation for possible values
+  #  directory: "/" # Location of package manifests
+  #  schedule:
+  #    interval: "weekly"
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The change comments out the configuration for the `nuget` package-ecosystem, effectively disabling it for now.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L7-R10): Commented out the `nuget` package-ecosystem configuration.